### PR TITLE
Dates and Blockchain Data Size in Intro

### DIFF
--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -22,7 +22,7 @@
 
 static const uint64_t GB_BYTES = 1000000000LL;
 /* Minimum free space (in GB) needed for data directory */
-static const uint64_t BLOCK_CHAIN_SIZE = 18;
+static const uint64_t BLOCK_CHAIN_SIZE = 8;
 /* Minimum free space (in GB) needed for data directory when pruned; Does not include prune target */
 static const uint64_t CHAIN_STATE_SIZE = 3;
 /* Total required space (in GB) depending on user choice (prune, not prune) */
@@ -126,7 +126,7 @@ Intro::Intro(QWidget *parent) :
     ui->lblExplanation1->setText(ui->lblExplanation1->text()
         .arg(tr(PACKAGE_NAME))
         .arg(BLOCK_CHAIN_SIZE)
-        .arg(2009)
+        .arg(2018)
         .arg(tr("Australiacash"))
     );
     ui->lblExplanation2->setText(ui->lblExplanation2->text().arg(tr(PACKAGE_NAME)));


### PR DESCRIPTION
Fix earliest transaction date.
Make Blockchain data directory size estimate smaller but large enough for future growth.